### PR TITLE
Fix elliptical_arc_by and documentation test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,9 @@ use std::{fmt::{self, Display, Formatter}, f32::consts::PI};
 /// The data associated with an SVG path. Implements `Display` for inclusion in format strings
 /// like this:
 /// ```rust
+/// # use svg_path::Path;
 /// let path = Path::new();
-/// let tag = format!(r#"<path d="{}"></path>"#);
+/// let tag = format!(r#"<path d="{}"></path>"#, path);
 /// ```
 #[derive(Clone)]
 pub struct Path {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl Path {
         let large_arc = if large_arc { 1 } else { 0 };
         let sweep = if sweep { 1 } else { 0 };
         fmt::write(&mut self.inner, 
-            format_args!("A {} {} {} {} {} {} {}", rx, ry, xrot, large_arc, sweep, dx, dy)
+            format_args!("a {} {} {} {} {} {} {}", rx, ry, xrot, large_arc, sweep, dx, dy)
         ).unwrap();
         self
     }


### PR DESCRIPTION
Hi, I found your library useful for a project but it has a bug where `elliptical_arc_by` appends `A` instead of `a` to the string.

Also fixed the docs to pass `cargo test`.